### PR TITLE
Check hopper attached chest for items to pull closer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ run
 
 # Files from Forge MDK
 forge*changelog.txt
+
+
+logs


### PR DESCRIPTION
This will allow magnets on top of hoppers to attract items that belong in the chest they are attached to.

Additionally, this fixes the issue where some items weren't dropping into the hopper because they weren't able to make it over the lip of the hopper if they were below the height of it.
